### PR TITLE
[FIX] Index can be only integer

### DIFF
--- a/lib/pbnt/Distribution.py
+++ b/lib/pbnt/Distribution.py
@@ -98,7 +98,7 @@ class Potential(object):
         if isinstance(index, (int, float, long)):
             index = [index]
         # assert(len(index) == len(axis))
-        tmp = zeros(self.nDims) - 1
+        tmp = zeros((self.nDims,), , dtype=int) - 1
         if len(axis) > 0:
             tmp[axis] = index
         indexStr = ""

--- a/lib/pbnt/Distribution.py
+++ b/lib/pbnt/Distribution.py
@@ -98,7 +98,7 @@ class Potential(object):
         if isinstance(index, (int, float, long)):
             index = [index]
         # assert(len(index) == len(axis))
-        tmp = zeros((self.nDims,), , dtype=int) - 1
+        tmp = zeros((self.nDims,), dtype=int) - 1
         if len(axis) > 0:
             tmp[axis] = index
         indexStr = ""


### PR DESCRIPTION
numpy zeros gave float array. We need integer array for index.